### PR TITLE
fix: Fix Styling on Connect Tab

### DIFF
--- a/src/tabs/connect/Connect.js
+++ b/src/tabs/connect/Connect.js
@@ -3,17 +3,12 @@ import { ScrollView, SafeAreaView } from 'react-native';
 import { Query } from 'react-apollo';
 import PropTypes from 'prop-types';
 
-import { BackgroundView, styled } from '@apollosproject/ui-kit';
+import { BackgroundView } from '@apollosproject/ui-kit';
 import ActionTable from './ActionTable';
 import ActionBar from './ActionBar';
 import UserAvatarHeader from './UserAvatarHeader';
 import { RecentlyLikedTileFeedConnected } from './RecentlyLikedTileFeed';
 import GET_USER_PROFILE from './getUserProfile';
-
-const ScrollViewWithPadding = styled(({ theme }) => ({
-  height: '100%',
-  marginTop: theme.sizing.baseUnit * 2,
-}))(ScrollView);
 
 class Connect extends PureComponent {
   static navigationOptions = () => ({
@@ -32,7 +27,7 @@ class Connect extends PureComponent {
     return (
       <BackgroundView>
         <SafeAreaView>
-          <ScrollViewWithPadding>
+          <ScrollView>
             <UserAvatarHeader key="UserAvatarHeaderConnected" />
             <ActionBar />
             <RecentlyLikedTileFeedConnected />
@@ -43,7 +38,7 @@ class Connect extends PureComponent {
                 } = {},
               }) => <ActionTable isGroupLeader={isGroupLeader} />}
             </Query>
-          </ScrollViewWithPadding>
+          </ScrollView>
         </SafeAreaView>
       </BackgroundView>
     );


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the the Connect tab so that the last link on the page is fully visible.

Before:
![Screenshot 2020-01-14 15 05 09](https://user-images.githubusercontent.com/3229463/72381282-2981bb00-36e5-11ea-893e-e8c0647a2fce.png)
After:
![Screenshot 2020-01-14 15 25 54](https://user-images.githubusercontent.com/3229463/72381283-2981bb00-36e5-11ea-924e-609a7af20b9c.png)
![Screenshot 2020-01-14 15 32 52](https://user-images.githubusercontent.com/3229463/72381284-2981bb00-36e5-11ea-9818-29298bce9666.png)

### How do I test this PR?
Go to the Connect tab and you should see the full bottom link, not half of it.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
