### PR TITLE
chore: Notifies for Bad Content Images

### DIFF
--- a/src/content-single/HTMLContent/index.js
+++ b/src/content-single/HTMLContent/index.js
@@ -3,14 +3,36 @@ import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 
-import HTMLView from '@apollosproject/ui-htmlview';
+import HTMLView, { defaultRenderer } from '@apollosproject/ui-htmlview';
 import { ErrorCard } from '@apollosproject/ui-kit';
 
+import bugsnag from '../../bugsnag';
 import GET_CONTENT_ITEM_CONTENT from './getContentItemContent';
 
 function handlePressAnchor(url) {
   return InAppBrowser.open(url);
 }
+
+const isLocalImg = (src) => src.startsWith('/');
+
+const customRenderer = (contentId) => (node, ...otherArgs) => {
+  if (node.name === 'img' && isLocalImg(node.attribs.src)) {
+    bugsnag.notify(new Error(`Bad image URL`), (report) => {
+      // eslint-disable-next-line
+      report.metaData = {
+        metaData: { url: node.attribs.src, contentId },
+        severity: 'warning',
+      };
+    });
+    return null;
+  }
+  return defaultRenderer(node, ...otherArgs);
+};
+const CustomHTMLView = (props) => (
+  <HTMLView renderer={customRenderer(props.contentId)} {...props} />
+);
+
+CustomHTMLView.propTypes = { contentId: PropTypes.string };
 
 const HTMLContent = ({ contentId }) => {
   if (!contentId) return <HTMLView isLoading />;
@@ -22,18 +44,19 @@ const HTMLContent = ({ contentId }) => {
       fetchPolicy={'cache-and-network'}
     >
       {({
-        data: { node: { htmlContent, summary } = {} } = {},
+        data: { node: { htmlContent, summary, id } = {} } = {},
         loading,
         error,
       }) => {
         if (!htmlContent && error) return <ErrorCard error={error} />;
         return (
-          <HTMLView
+          <CustomHTMLView
+            contentId={id}
             isLoading={!htmlContent && !summary && loading}
             onPressAnchor={handlePressAnchor}
           >
             {htmlContent || summary}
-          </HTMLView>
+          </CustomHTMLView>
         );
       }}
     </Query>


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2020-01-15 at 11 54 25 AM](https://user-images.githubusercontent.com/2659478/72454601-28a56380-378f-11ea-9c4f-aafaa616fe47.png)


### What does this PR do, or why is it needed?

This checks for bad image URLs in content and notifies us with the url and content ID via bugsnag. Also hides the big ugly grey box.

### How do I test this PR?

Pull up the Summer 2020 Intern content in staff updates. Drop in a console.log to see it happen if you want.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._