### PR TITLE
fix: Adds a navigation queue

### DIFF
--- a/src/NavigationService.js
+++ b/src/NavigationService.js
@@ -1,31 +1,62 @@
-import { NavigationActions } from 'react-navigation';
+import { StackActions, NavigationActions } from 'react-navigation';
 
 let _navigator;
+let _pendingActions = [];
+
+const performWhenReady = (func) => (...args) => {
+  if (_navigator) {
+    func(...args);
+  } else {
+    _pendingActions.push(() => func(...args));
+  }
+};
 
 const setTopLevelNavigator = (navigatorRef) => {
   _navigator = navigatorRef;
+  if (_pendingActions.length > 0) {
+    _pendingActions.forEach((action) => action());
+  }
+  _pendingActions = [];
 };
 
-const navigate = (routeName, params) => {
+const navigate = performWhenReady((routeName, params) => {
   _navigator.dispatch(
     NavigationActions.navigate({
       routeName,
       params,
     })
   );
-};
+});
 
-const goBack = (from) => {
+const resetToAuth = performWhenReady(() => {
+  _navigator.dispatch(
+    StackActions.reset({
+      index: 0,
+      key: null,
+      actions: [
+        NavigationActions.navigate({
+          routeName: 'Auth',
+          action: NavigationActions.navigate({
+            routeName: 'AuthSMSPhoneEntryConnected',
+          }),
+        }),
+      ],
+    })
+  );
+});
+
+const goBack = performWhenReady((from) => {
   let key;
   if (from) {
     const route = _navigator.state.nav.routes.find((r) => r.routeName === from);
     if (route) ({ key } = route);
   }
   _navigator.dispatch(NavigationActions.back({ key }));
-};
+});
 
 export default {
   setTopLevelNavigator,
   navigate,
   goBack,
+  resetToAuth,
 };


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Essentially what's happening is we are trying to use the navigator before it's mounted (*still not sure why this happening*). This creates a queue to wait until it is mounted.

### How do I test this PR?

No idea.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [ ] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._