### PR TITLE
fix: Fixes auth reset thrashing

### DIFF
--- a/src/NavigationService.js
+++ b/src/NavigationService.js
@@ -1,4 +1,4 @@
-import { NavigationActions } from 'react-navigation';
+import { StackActions, NavigationActions } from 'react-navigation';
 
 let _navigator;
 
@@ -11,6 +11,23 @@ const navigate = (routeName, params) => {
     NavigationActions.navigate({
       routeName,
       params,
+    })
+  );
+};
+
+const resetToAuth = () => {
+  _navigator.dispatch(
+    StackActions.reset({
+      index: 0,
+      key: null,
+      actions: [
+        NavigationActions.navigate({
+          routeName: 'Auth',
+          action: NavigationActions.navigate({
+            routeName: 'AuthSMSPhoneEntryConnected',
+          }),
+        }),
+      ],
     })
   );
 };
@@ -28,4 +45,5 @@ export default {
   setTopLevelNavigator,
   navigate,
   goBack,
+  resetToAuth,
 };

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,12 +13,17 @@ import NavigationService from '../NavigationService';
 import httpLink from './httpLink';
 import cache, { ensureCacheHydration, MARK_CACHE_LOADED } from './cache';
 
-const goToAuth = () => NavigationService.navigate('Auth');
+const goToAuth = () => NavigationService.resetToAuth();
 const wipeData = () => cache.writeData({ data: defaults });
 
 let resetStore;
-const onAuthError = () => {
-  resetStore();
+let storeIsResetting = false;
+const onAuthError = async () => {
+  if (!storeIsResetting) {
+    storeIsResetting = true;
+    await resetStore();
+  }
+  storeIsResetting = false;
   goToAuth();
 };
 

--- a/src/user-settings/index.js
+++ b/src/user-settings/index.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react';
 import { ScrollView } from 'react-native';
 import Config from 'react-native-config';
-import { StackActions, NavigationActions } from 'react-navigation';
 import PropTypes from 'prop-types';
 import { Query, Mutation } from 'react-apollo';
 import { getVersion, getBuildNumber } from 'react-native-device-info';
@@ -17,6 +16,8 @@ import {
   ActivityIndicator,
 } from '@apollosproject/ui-kit';
 import { GET_LOGIN_STATE, LOGOUT } from '@apollosproject/ui-auth';
+import NavigationService from '../NavigationService';
+
 import { WebBrowserConsumer } from '../ui/WebBrowser';
 
 import ChangeAvatar from './ChangeAvatar';
@@ -114,21 +115,7 @@ class UserSettings extends PureComponent {
                                 await handleLogout();
                                 // This resets the navigation stack, and the navigates to the first auth screen.
                                 // This ensures that user isn't navigated to a subscreen of Auth, like the pin entry screen.
-                                await this.props.navigation.dispatch(
-                                  StackActions.reset({
-                                    index: 0,
-                                    key: null,
-                                    actions: [
-                                      NavigationActions.navigate({
-                                        routeName: 'Auth',
-                                        action: NavigationActions.navigate({
-                                          routeName:
-                                            'AuthSMSPhoneEntryConnected',
-                                        }),
-                                      }),
-                                    ],
-                                  })
-                                );
+                                await NavigationService.resetToAuth();
                               }}
                             >
                               <Cell>


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

This sets a lock to make sure store is completely reset before navigating to auth. Core commit is [here](https://github.com/ApollosProject/apollos-prototype/commit/0730a7b371baf6cd50ce31cd84b13a76375004d5#diff-0249d03ebc156ed7c86860d0dc04af53)

### How do I test this PR?

- Make sure logout works properly
- Make sure app kicks out properly. Open up debugger and clear async storage (removes the token) to generate an auth error that should kick back to auth.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [ ] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._