### PR TITLE
chore: Additional 1.3.0 UI Fixes

### DIFF
--- a/loadConfig.js
+++ b/loadConfig.js
@@ -1,4 +1,65 @@
 import ApollosConfig from '@apollosproject/config';
 import FRAGMENTS from '@apollosproject/ui-fragments';
+import gql from 'graphql-tag';
 
-ApollosConfig.loadJs({ FRAGMENTS });
+ApollosConfig.loadJs({
+  FRAGMENTS: {
+    ...FRAGMENTS,
+    CONTENT_CARD_FRAGMENT: gql`
+      fragment contentCardFragment on ContentItem {
+        id
+        __typename
+        coverImage {
+          sources {
+            uri
+          }
+        }
+        theme {
+          type
+          colors {
+            primary
+            secondary
+            screen
+            paper
+          }
+        }
+        title
+        hyphenatedTitle: title(hyphenated: true)
+        summary
+        ... on MediaContentItem {
+          videos {
+            sources {
+              uri
+            }
+          }
+          parentChannel {
+            id
+            name
+          }
+        }
+        ... on WeekendContentItem {
+          videos {
+            sources {
+              uri
+            }
+            thumbnail {
+              sources {
+                uri
+              }
+            }
+          }
+          parentChannel {
+            id
+            name
+          }
+        }
+        ... on DevotionalContentItem {
+          parentChannel {
+            id
+            name
+          }
+        }
+      }
+    `,
+  },
+});

--- a/src/content-feed/__snapshots__/content-feed.tests.js.snap
+++ b/src/content-feed/__snapshots__/content-feed.tests.js.snap
@@ -76,7 +76,6 @@ exports[`content feed query component renders a feedview after successful query 
     onEndReachedThreshold={0.7}
     onLayout={[Function]}
     onMomentumScrollEnd={[Function]}
-    onPressItem={[Function]}
     onRefresh={[Function]}
     onScroll={[Function]}
     onScrollBeginDrag={[Function]}

--- a/src/content-feed/index.js
+++ b/src/content-feed/index.js
@@ -8,8 +8,14 @@ import {
   fetchMoreResolver,
 } from '@apollosproject/ui-connected';
 
-import { BackgroundView, FeedView } from '@apollosproject/ui-kit';
+import {
+  BackgroundView,
+  FeedView,
+  TouchableScale,
+  DefaultCard,
+} from '@apollosproject/ui-kit';
 
+import BrandedCard from '../ui/BrandedCard';
 import GET_CONTENT_FEED from './getContentFeed';
 /**
  * This is where the component description lives
@@ -37,11 +43,23 @@ class ContentFeed extends PureComponent {
   /** Function that is called when a card in the feed is pressed.
    * Takes the user to the ContentSingle
    */
-  handleOnPress = (item) =>
+  handleOnPress = (item) => {
     this.props.navigation.navigate('ContentSingle', {
       itemId: item.id,
       sharing: item.sharing,
     });
+  };
+
+  getComponent = (item) => {
+    switch (get(item, '__typename')) {
+      case 'WeekendContentItem':
+      case 'ContentSeriesContentItem':
+      case 'DevotionalContentItem':
+        return BrandedCard;
+      default:
+        return DefaultCard;
+    }
+  };
 
   render() {
     const { navigation } = this.props;
@@ -55,7 +73,6 @@ class ContentFeed extends PureComponent {
         >
           {({ loading, error, data, refetch, fetchMore, variables }) => (
             <FeedView
-              ListItemComponent={ContentCardConnected}
               content={get(
                 data,
                 'node.childContentItemsConnection.edges',
@@ -70,7 +87,22 @@ class ContentFeed extends PureComponent {
               isLoading={loading}
               error={error}
               refetch={refetch}
-              onPressItem={this.handleOnPress}
+              renderItem={({ item }) => (
+                <TouchableScale
+                  onPress={() => {
+                    this.handleOnPress(item);
+                  }}
+                >
+                  <ContentCardConnected
+                    Component={this.getComponent(item)}
+                    contentId={item.isLoading ? null : get(item, 'id')}
+                    labelText={
+                      item.parentChannel &&
+                      item.parentChannel.name.split(' - ').pop()
+                    }
+                  />
+                </TouchableScale>
+              )}
             />
           )}
         </Query>

--- a/src/content-single/HorizontalContentFeed/index.js
+++ b/src/content-single/HorizontalContentFeed/index.js
@@ -40,8 +40,15 @@ class HorizontalContentFeed extends Component {
         disabled={disabled}
       >
         <HorizontalContentCardConnected
+          Component={({ coverImage, ...props }) => (
+            <HorizontalContentCardConnected.defaultProps.Component
+              coverImage={null}
+              {...props}
+            />
+          )}
           contentId={itemId}
           disabled={disabled}
+          labelText={''}
         />
       </TouchableScale>
     );

--- a/src/content-single/HorizontalContentFeed/index.js
+++ b/src/content-single/HorizontalContentFeed/index.js
@@ -40,12 +40,28 @@ class HorizontalContentFeed extends Component {
         disabled={disabled}
       >
         <HorizontalContentCardConnected
-          Component={({ coverImage, ...props }) => (
-            <HorizontalContentCardConnected.defaultProps.Component
-              coverImage={null}
-              {...props}
-            />
-          )}
+          Component={({ coverImage, ...props }) => {
+            switch (get(item, '__typename')) {
+              case 'WeekendContentItem':
+                return (
+                  <HorizontalContentCardConnected.defaultProps.Component
+                    coverImage={
+                      item.videos.length
+                        ? item.videos[0].thumbnail.sources
+                        : null
+                    }
+                    {...props}
+                  />
+                );
+              default:
+                return (
+                  <HorizontalContentCardConnected.defaultProps.Component
+                    coverImage={null}
+                    {...props}
+                  />
+                );
+            }
+          }}
           contentId={itemId}
           disabled={disabled}
           labelText={''}

--- a/src/prayer/PrayerTabView/PrayerTab.js
+++ b/src/prayer/PrayerTabView/PrayerTab.js
@@ -19,10 +19,6 @@ const ContentView = styled(({ theme }) => ({
   marginBottom: theme.sizing.baseUnit * 2,
 }))(FlexedView);
 
-const StyledButton = styled({
-  width: '100%',
-})(Button);
-
 const PrayerTab = memo(
   ({ prayers, type, title, description, loading, ...props }) => (
     <ContentView>
@@ -37,7 +33,7 @@ const PrayerTab = memo(
             <VerticalPaddedView>
               <BodyText placeholder={'Loading Prayers'}>{description}</BodyText>
             </VerticalPaddedView>
-            <StyledButton
+            <Button
               title="Start praying"
               onPress={() =>
                 props.navigation.navigate('PrayerList', {

--- a/src/tabs/connect/Connect.js
+++ b/src/tabs/connect/Connect.js
@@ -4,8 +4,8 @@ import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-navigation';
 import PropTypes from 'prop-types';
 
-import { HorizontalLikedContentFeedConnected } from '@apollosproject/ui-connected';
 import { BackgroundView } from '@apollosproject/ui-kit';
+import HorizontalLikedContentFeedConnected from '../../ui/HorizontalLikedContentFeedConnected';
 import ActionTable from './ActionTable';
 import ActionBar from './ActionBar';
 import UserAvatarHeader from './UserAvatarHeader';

--- a/src/tabs/discover/DiscoverFeed/TileContentFeed.js
+++ b/src/tabs/discover/DiscoverFeed/TileContentFeed.js
@@ -55,7 +55,6 @@ const loadingStateObject = {
 };
 
 const getTitle = (item) => {
-  console.log('item = ', item.__typename);
   switch (get(item, '__typename')) {
     case 'WeekendContentItem':
     case 'ContentSeriesContentItem':

--- a/src/ui/HorizontalLikedContentFeed.js
+++ b/src/ui/HorizontalLikedContentFeed.js
@@ -1,0 +1,140 @@
+import React, { Component } from 'react';
+import { get } from 'lodash';
+import { View } from 'react-native';
+import { withNavigation } from 'react-navigation';
+import PropTypes from 'prop-types';
+
+import {
+  styled,
+  withTheme,
+  PaddedView,
+  H5,
+  H6,
+  HorizontalTileFeed,
+  ButtonLink,
+  TouchableScale,
+  Touchable,
+  withIsLoading,
+} from '@apollosproject/ui-kit';
+
+import { HorizontalContentCardConnected } from '@apollosproject/ui-connected';
+
+const RowHeader = styled(({ theme }) => ({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  zIndex: 2, // UX hack to improve tapability. Positions RowHeader above StyledHorizontalTileFeed
+  paddingTop: theme.sizing.baseUnit * 0.5,
+  paddingLeft: theme.sizing.baseUnit,
+}))(View);
+
+const Name = styled({
+  flexGrow: 2,
+})(View);
+
+const ButtonLinkSpacing = styled(({ theme }) => ({
+  flexDirection: 'row', // correctly positions the loading state
+  justifyContent: 'flex-end', // correctly positions the loading state
+  padding: theme.sizing.baseUnit, // UX hack to improve tapability.
+}))(View);
+
+const AndroidTouchableFix = withTheme(({ theme }) => ({
+  borderRadius: theme.sizing.baseBorderRadius / 2,
+}))(Touchable);
+
+const StyledHorizontalTileFeed = styled(({ theme }) => ({
+  /* UX hack to improve tapability. The magic number below happens to be the number of pixels that
+   * aligns everything in the same place as if none of the UX hacks were there. */
+  marginTop: theme.sizing.baseUnit * -1.25,
+  zIndex: 1,
+}))(HorizontalTileFeed);
+
+class HorizontalLikedContentFeed extends Component {
+  loadingStateObject = {
+    id: 'fake_id',
+    title: '',
+    coverImage: [],
+  };
+
+  static propTypes = {
+    navigation: PropTypes.shape({
+      navigate: PropTypes.func,
+    }),
+    isLoading: PropTypes.bool,
+    name: PropTypes.string,
+    content: PropTypes.arrayOf(
+      PropTypes.any // this component doesn't care about the shape of `node`, just that it exists
+    ),
+  };
+
+  titleImageItem = ({ item }) => (
+    <TouchableScale
+      onPress={() => {
+        this.props.navigation.push('ContentSingle', {
+          itemId: item.id,
+        });
+      }}
+    >
+      <HorizontalContentCardConnected
+        Component={({ coverImage, ...props }) => {
+          switch (get(item, '__typename')) {
+            case 'WeekendContentItem':
+              return (
+                <HorizontalContentCardConnected.defaultProps.Component
+                  coverImage={
+                    item.videos.length ? item.videos[0].thumbnail.sources : null
+                  }
+                  {...props}
+                />
+              );
+            default:
+              return (
+                <HorizontalContentCardConnected.defaultProps.Component
+                  coverImage={null}
+                  {...props}
+                />
+              );
+          }
+        }}
+        labelText={''}
+        isLoading={item.isLoading}
+        contentId={item.id}
+      />
+    </TouchableScale>
+  );
+
+  render() {
+    const { isLoading, name, navigation, content = [] } = this.props;
+
+    return (
+      <PaddedView horizontal={false}>
+        <RowHeader>
+          <Name>
+            <H5>{name}</H5>
+          </Name>
+
+          <AndroidTouchableFix
+            onPress={() => {
+              navigation.navigate('LikedContentFeedConnected');
+            }}
+          >
+            <ButtonLinkSpacing>
+              <H6>
+                {/* we have to wrap "View All" in a ButtonLink twice to inherit styles and color correctly. */}
+                <ButtonLink>View All</ButtonLink>
+              </H6>
+            </ButtonLinkSpacing>
+          </AndroidTouchableFix>
+        </RowHeader>
+        <StyledHorizontalTileFeed
+          content={content}
+          renderItem={this.titleImageItem}
+          loadingStateObject={this.loadingStateObject}
+          isLoading={isLoading}
+        />
+      </PaddedView>
+    );
+  }
+}
+
+export default withNavigation(withIsLoading(HorizontalLikedContentFeed));

--- a/src/ui/HorizontalLikedContentFeedConnected.js
+++ b/src/ui/HorizontalLikedContentFeedConnected.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Query } from 'react-apollo';
+import PropTypes from 'prop-types';
+
+import { GET_LIKED_CONTENT } from '@apollosproject/ui-connected';
+
+import HorizontalLikedContentFeed from './HorizontalLikedContentFeed';
+
+const HorizontalLikedContentFeedConnected = ({ Component, navigation }) => (
+  <Query
+    query={GET_LIKED_CONTENT}
+    fetchPolicy="cache-and-network"
+    variables={{ first: 3 }}
+  >
+    {({
+      loading,
+      data: { likedContent: { edges = [] } = { edges: [] } } = {},
+    }) => {
+      if (!edges.length) return null;
+      return (
+        <Component
+          id={'liked'}
+          name={'Recently Liked'}
+          content={edges.map((e) => e.node)}
+          isLoading={loading}
+          navigation={navigation}
+          loadingStateObject={{
+            title: 'Recently Liked',
+            isLoading: true,
+          }}
+        />
+      );
+    }}
+  </Query>
+);
+
+HorizontalLikedContentFeedConnected.propTypes = {
+  Component: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
+    PropTypes.object, // type check for React fragments
+  ]),
+  navigation: PropTypes.shape({
+    getParam: PropTypes.func,
+    navigate: PropTypes.func,
+  }),
+};
+
+HorizontalLikedContentFeedConnected.defaultProps = {
+  Component: HorizontalLikedContentFeed,
+};
+
+export default HorizontalLikedContentFeedConnected;


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR includes the following changes:
* Updated the Discover "View All" feed so that it uses the correct cards (i.e. Branded Card for Sermons, Default Card for Articles ... )
* Fixed "Start Praying" text on the button to be centered.
* Horizontal content cards: they will show sermon thumbnails for sermons and no background at all for anything else. This is in the content items themselves and the recently liked tile feed.
* Only the right things in the discover feed should show a pill with text. Everything else shouldn't ... anywhere.

Basically everything should pretty much look like it did before we updated.

### How do I test this PR?
Make sure everything looks like it did before we upgraded.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
