### PR TITLE
fix: Fixes Campaign Loading State

### DIFF
--- a/src/tabs/discover/SearchFeed/__snapshots__/SearchFeed.tests.js.snap
+++ b/src/tabs/discover/SearchFeed/__snapshots__/SearchFeed.tests.js.snap
@@ -469,7 +469,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                                 "borderRadius": 16,
                                 "borderWidth": 0,
                                 "height": 32,
-                                "marginBottom": 16,
                                 "paddingHorizontal": 12,
                                 "width": 64,
                               }
@@ -1427,7 +1426,6 @@ Celebrate your freedom in Christ — in the car, shower, cubicle or wherever you
                                 "borderRadius": 16,
                                 "borderWidth": 0,
                                 "height": 32,
-                                "marginBottom": 16,
                                 "paddingHorizontal": 12,
                                 "width": 64,
                               }

--- a/src/ui/BrandedCard.js
+++ b/src/ui/BrandedCard.js
@@ -4,41 +4,14 @@ import { get } from 'lodash';
 
 import { FeaturedCard, CardLabel, styled } from '@apollosproject/ui-kit';
 
-// If we decide to go back to what we had before:
-// * Uncomment the LiveAwareLabel code below
-// * Remove hasAction, campaign, and summary from props and propTypes
-// * Remove the StyledCardLabel & getTheme functions
-// * Change LabelComponent to be:
-// LabelComponent={
-//    labelText ? (
-//      <LiveAwareLabel
-//        type={get(theme, 'type') === 'LIGHT' ? 'darkOverlay' : undefined}
-//        customTheme={theme}
-//        isLive={isLive}
-//        title={labelText}
-//      />
-//    ) : null
-
-// const LiveAwareLabel = withTheme(	const StyledCardLabel = styled(({ theme }) => ({
-//   ({ customTheme, isLive, title, type, theme }) => ({	  marginBottom: theme.sizing.baseUnit,
-//     ...(isLive	}))(CardLabel);
-//       ? {
-//           title: 'Live',
-//           type: 'secondary',
-//           icon: 'live-dot',
-//           iconSize: theme.helpers.rem(0.4375), // using our typographic size unit based on fontSize so that the icon scales correctly with font size changes.
-//         }
-//       : {
-//           title,
-//           type: !customTheme ? 'secondary' : type,
-//         }),
-//     style: { marginBottom: theme.sizing.baseUnit },
-//   })
-// )(CardLabel);
-
-const StyledCardLabel = styled(({ theme }) => ({
-  marginBottom: theme.sizing.baseUnit,
-}))(CardLabel);
+const StyledCardLabel = styled(
+  ({ isLoading, theme }) =>
+    isLoading
+      ? {}
+      : {
+          marginBottom: theme.sizing.baseUnit,
+        }
+)(CardLabel);
 
 const getTheme = (theme) =>
   get(theme, 'type') === 'LIGHT' ? 'darkOverlay' : undefined;
@@ -59,6 +32,7 @@ const BrandedCard = ({
       ) : (
         labelText && (
           <StyledCardLabel
+            isLoading={otherProps.isLoading}
             title={labelText}
             type={theme ? getTheme(theme) : 'secondary'}
           />

--- a/src/ui/BrandedCard.js
+++ b/src/ui/BrandedCard.js
@@ -28,7 +28,10 @@ const BrandedCard = ({
   <FeaturedCard
     LabelComponent={
       campaign && isLive ? (
-        <StyledCardLabel title={"Today's Sermon"} />
+        <StyledCardLabel
+          isLoading={otherProps.isLoading}
+          title={"Today's Sermon"}
+        />
       ) : (
         labelText && (
           <StyledCardLabel


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2020-02-05 at 4 01 14 PM](https://user-images.githubusercontent.com/2659478/73882883-e375ce00-4830-11ea-979e-b078485d3841.png)


### What does this PR do, or why is it needed?

Gets rid of the strange green line under the campaign card loading state.

### How do I test this PR?

Set loading to `true` and watch it magically disappear!

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._