### PR TITLE
fix: Correct in-app browser close button text

### DIFF
--- a/src/content-single/MediaControls/index.js
+++ b/src/content-single/MediaControls/index.js
@@ -15,10 +15,8 @@ import {
 } from '@apollosproject/ui-kit';
 import { AnalyticsConsumer } from '@apollosproject/ui-analytics';
 import Analytics from 'appcenter-analytics';
-import {
-  LiveConsumer,
-  RockAuthedWebBrowser,
-} from '@apollosproject/ui-connected';
+import { LiveConsumer } from '@apollosproject/ui-connected';
+import RockAuthedWebBrowser from '../../ui/RockAuthedWebBrowser';
 import GET_CONTENT_MEDIA from './getContentMedia';
 
 const Container = styled(({ theme }) => ({

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ import { MediaPlayer } from '@apollosproject/ui-media-player';
 import Auth, { ProtectedRoute } from '@apollosproject/ui-auth';
 
 import { AnalyticsConsumer } from '@apollosproject/ui-analytics';
-import { RockAuthedWebBrowser } from '@apollosproject/ui-connected';
 
 import Providers from './Providers';
 import NavigationService from './NavigationService';
@@ -29,6 +28,7 @@ import Prayer from './prayer';
 import LandingScreen from './LandingScreen';
 import UserWebBrowser from './user-web-browser';
 import Onboarding from './ui/Onboarding';
+import RockAuthedWebBrowser from './ui/RockAuthedWebBrowser';
 
 // need to initialize error tracking at the entrypoint
 // eslint-disable-next-line

--- a/src/tabs/connect/ActionBar.js
+++ b/src/tabs/connect/ActionBar.js
@@ -24,7 +24,7 @@ const Toolbar = ({ navigation }) => (
           onPress={() =>
             openUrl(
               'https://newspring.cc/groups/?hidenav=true',
-              {},
+              { dismissButtonStyle: 'close' },
               { useRockToken: true }
             )
           }

--- a/src/tabs/connect/ActionBar.js
+++ b/src/tabs/connect/ActionBar.js
@@ -3,7 +3,7 @@ import Config from 'react-native-config';
 import { ActionBar, ActionBarItem } from '@apollosproject/ui-kit';
 import { withNavigation } from 'react-navigation';
 import PropTypes from 'prop-types';
-import { RockAuthedWebBrowser } from '@apollosproject/ui-connected';
+import RockAuthedWebBrowser from '../../ui/RockAuthedWebBrowser';
 
 const Toolbar = ({ navigation }) => (
   <RockAuthedWebBrowser>
@@ -24,7 +24,7 @@ const Toolbar = ({ navigation }) => (
           onPress={() =>
             openUrl(
               'https://newspring.cc/groups/?hidenav=true',
-              { dismissButtonStyle: 'close' },
+              {},
               { useRockToken: true }
             )
           }

--- a/src/tabs/connect/ActionTable/index.js
+++ b/src/tabs/connect/ActionTable/index.js
@@ -41,7 +41,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 'https://newspring.cc/connect/?hidenav=true',
-                {},
+                { dismissButtonStyle: 'close' },
                 { useRockToken: true }
               )
             }
@@ -56,7 +56,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 'https://newspring.cc/serving/?hidenav=true',
-                {},
+                { dismissButtonStyle: 'close' },
                 { useRockToken: true }
               )
             }
@@ -71,7 +71,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 'https://newspring.cc/missions/?hidenav=true',
-                {},
+                { dismissButtonStyle: 'close' },
                 { useRockToken: true }
               )
             }
@@ -88,7 +88,7 @@ const ActionTable = ({ isGroupLeader }) => (
                 onPress={() =>
                   openUrl(
                     'https://newspring.cc/groups/leader/?hidenav=true',
-                    {},
+                    { dismissButtonStyle: 'close' },
                     { useRockToken: true }
                   )
                 }
@@ -119,7 +119,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 `https://newspring.cc/workflows/530?Source=3&hidenav=true`,
-                {},
+                { dismissButtonStyle: 'close' },
                 { useRockToken: true }
               )
             }

--- a/src/tabs/connect/ActionTable/index.js
+++ b/src/tabs/connect/ActionTable/index.js
@@ -13,7 +13,7 @@ import {
   PaddedView,
   H4,
 } from '@apollosproject/ui-kit';
-import { RockAuthedWebBrowser } from '@apollosproject/ui-connected';
+import RockAuthedWebBrowser from '../../../ui/RockAuthedWebBrowser';
 import NavigationActions from '../../../NavigationService';
 
 const RowHeader = styled(({ theme }) => ({
@@ -41,7 +41,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 'https://newspring.cc/connect/?hidenav=true',
-                { dismissButtonStyle: 'close' },
+                {},
                 { useRockToken: true }
               )
             }
@@ -56,7 +56,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 'https://newspring.cc/serving/?hidenav=true',
-                { dismissButtonStyle: 'close' },
+                {},
                 { useRockToken: true }
               )
             }
@@ -71,7 +71,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 'https://newspring.cc/missions/?hidenav=true',
-                { dismissButtonStyle: 'close' },
+                {},
                 { useRockToken: true }
               )
             }
@@ -88,7 +88,7 @@ const ActionTable = ({ isGroupLeader }) => (
                 onPress={() =>
                   openUrl(
                     'https://newspring.cc/groups/leader/?hidenav=true',
-                    { dismissButtonStyle: 'close' },
+                    {},
                     { useRockToken: true }
                   )
                 }
@@ -119,7 +119,7 @@ const ActionTable = ({ isGroupLeader }) => (
             onPress={() =>
               openUrl(
                 `https://newspring.cc/workflows/530?Source=3&hidenav=true`,
-                { dismissButtonStyle: 'close' },
+                {},
                 { useRockToken: true }
               )
             }

--- a/src/testing-control-panel/index.js
+++ b/src/testing-control-panel/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import { TableView } from '@apollosproject/ui-kit';
-import { RockAuthedWebBrowser } from '@apollosproject/ui-connected';
+import RockAuthedWebBrowser from '../ui/RockAuthedWebBrowser';
 import { UserWebBrowserConsumer } from '../user-web-browser';
 import TouchableCell from './TouchableCell';
 

--- a/src/ui/LiveButton.js
+++ b/src/ui/LiveButton.js
@@ -11,10 +11,8 @@ import {
 } from '@apollosproject/ui-kit';
 import { AnalyticsConsumer } from '@apollosproject/ui-analytics';
 import Analytics from 'appcenter-analytics';
-import {
-  RockAuthedWebBrowser,
-  LiveConsumer,
-} from '@apollosproject/ui-connected';
+import { LiveConsumer } from '@apollosproject/ui-connected';
+import RockAuthedWebBrowser from './RockAuthedWebBrowser';
 
 const LiveCard = styled(({ theme }) => ({
   backgroundColor: theme.colors.lightSecondary,

--- a/src/ui/RockAuthedInAppBrowser.js
+++ b/src/ui/RockAuthedInAppBrowser.js
@@ -1,0 +1,54 @@
+import { Linking } from 'react-native';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+
+import GET_ROCK_AUTH_DETAILS from './getRockAuthDetails';
+
+export const getRockAuthDetails = async (client) => {
+  const { data: { currentUser: { rock } = {} } = {} } = await client.query({
+    query: GET_ROCK_AUTH_DETAILS,
+    fetchPolicy: 'network-only',
+  });
+  return rock;
+};
+
+const RockAuthedInAppBrowser = {
+  open: async (
+    baseURL,
+    { client, ...options },
+    auth = { useRockCookie: false, useRockToken: false }
+  ) => {
+    const url = new URL(baseURL);
+    // NOTE: RN adds a trailing slash
+    // https://github.com/facebook/react-native/issues/24428
+    url._url = url.toString().endsWith('/')
+      ? url.toString().slice(0, -1)
+      : url.toString();
+
+    const { authCookie, authToken } = await getRockAuthDetails(client);
+    let headers = {};
+    if (auth.useRockCookie && authCookie) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "iOS doesn't support headers, you may want to use src/user-web-view"
+      );
+      headers = { Cookie: authCookie };
+    }
+
+    if (auth.useRockToken && authToken) {
+      url.searchParams.append('rckipid', authToken);
+    }
+    try {
+      if (await InAppBrowser.isAvailable()) {
+        InAppBrowser.open(url.toString(), {
+          headers,
+          ...options,
+        });
+      } else Linking.openURL(url.toString());
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    }
+  },
+};
+
+export default RockAuthedInAppBrowser;

--- a/src/ui/RockAuthedWebBrowser.js
+++ b/src/ui/RockAuthedWebBrowser.js
@@ -1,0 +1,44 @@
+// Provider API for WebBrowser that injects theme values and defaults to the web browser:
+import { Platform } from 'react-native';
+import { withApollo } from 'react-apollo';
+
+import { withTheme } from '@apollosproject/ui-kit';
+
+import RockAuthedInAppBrowser from './RockAuthedInAppBrowser';
+
+const RockAuthedWebBrowserWithClient = ({ children, client, paper, primary }) =>
+  children((url, iABOptions = {}, authOptions = {}) =>
+    RockAuthedInAppBrowser.open(
+      url,
+      {
+        client,
+        ...Platform.select({
+          ios: {
+            dismissButtonStyle: 'close',
+            preferredBarTintColor: paper,
+            preferredControlTintColor: primary,
+            readerMode: false,
+          },
+          android: {
+            toolbarColor: paper,
+            enableDefaultShare: true,
+            showTitle: true,
+            secondaryToolbarColor: 'black',
+            enableUrlBarHiding: true,
+            forceCloseOnRedirection: false,
+          },
+        }),
+        ...iABOptions,
+      },
+      authOptions
+    )
+  );
+
+const RockAuthedWebBrowser = withApollo(
+  withTheme(({ theme: { colors: { paper, primary } = {} } = {} }) => ({
+    paper,
+    primary,
+  }))(RockAuthedWebBrowserWithClient)
+);
+
+export default RockAuthedWebBrowser;

--- a/src/ui/getRockAuthDetails.js
+++ b/src/ui/getRockAuthDetails.js
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+export const GET_ROCK_AUTH_DETAILS = gql`
+  query RockAuthDetails {
+    currentUser {
+      id
+      rock {
+        authCookie
+        authToken
+      }
+    }
+  }
+`;
+
+export default GET_ROCK_AUTH_DETAILS;

--- a/src/user-settings/index.js
+++ b/src/user-settings/index.js
@@ -17,7 +17,7 @@ import {
 } from '@apollosproject/ui-kit';
 
 import { GET_LOGIN_STATE, LOGOUT } from '@apollosproject/ui-auth';
-import { RockAuthedWebBrowser } from '@apollosproject/ui-connected';
+import RockAuthedWebBrowser from '../ui/RockAuthedWebBrowser';
 import NavigationService from '../NavigationService';
 
 import ChangeAvatar from './ChangeAvatar';


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
Changes the text on the in-app browser close button to say "Close" instead of "Cancel".

### How do I test this PR?
Test the links in the connect tab that use the in-app browser to see that the text of the close button is now "Close".

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
