### PR TITLE
fix: Fixed the horizontal liked content feed card images

### DIFF
--- a/src/ui/HorizontalLikedContentFeed.js
+++ b/src/ui/HorizontalLikedContentFeed.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { get } from 'lodash';
 import { View } from 'react-native';
 import { withNavigation } from 'react-navigation';
 import PropTypes from 'prop-types';
@@ -76,26 +75,6 @@ class HorizontalLikedContentFeed extends Component {
       }}
     >
       <HorizontalContentCardConnected
-        Component={({ coverImage, ...props }) => {
-          switch (get(item, '__typename')) {
-            case 'WeekendContentItem':
-              return (
-                <HorizontalContentCardConnected.defaultProps.Component
-                  coverImage={
-                    item.videos.length ? item.videos[0].thumbnail.sources : null
-                  }
-                  {...props}
-                />
-              );
-            default:
-              return (
-                <HorizontalContentCardConnected.defaultProps.Component
-                  coverImage={null}
-                  {...props}
-                />
-              );
-          }
-        }}
         labelText={''}
         isLoading={item.isLoading}
         contentId={item.id}


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the horizontal liked content feed images so that they have correct cover images.

![Screenshot 2020-02-17 13 43 41](https://user-images.githubusercontent.com/3229463/74679793-cf18c600-518c-11ea-97d0-5763e5687d54.png)

### How do I test this PR?
Like some stuff and make sure that the correct images show up in the horizontal liked content feed.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
