### PR TITLE
fix: Removed series tag from content without children

### DIFF
--- a/src/ui/HorizontalContentSeriesFeedConnected.js
+++ b/src/ui/HorizontalContentSeriesFeedConnected.js
@@ -113,7 +113,7 @@ class HorizontalContentSeriesFeedConnected extends Component {
     );
     const initialScrollIndex = currentIndex === -1 ? 0 : currentIndex;
 
-    return (
+    return content && content.length ? (
       <PaddedView horizontal={false}>
         <PaddedView vertical={false}>
           <H5>In this series</H5>
@@ -155,7 +155,7 @@ class HorizontalContentSeriesFeedConnected extends Component {
           }
         />
       </PaddedView>
-    );
+    ) : null;
   };
 
   render() {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR removes the "In this series" tag from appearing on content that did not have children/siblings.

### How do I test this PR?
Check all the different types of content and make sure that the "In this series" tag only shows on items that actually have child/sibling content.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
