### PR TITLE
fix: Fix prayer top and bottom margins

### DIFF
--- a/src/prayer/PrayerSingle/__snapshots__/PrayerSingle.tests.js.snap
+++ b/src/prayer/PrayerSingle/__snapshots__/PrayerSingle.tests.js.snap
@@ -15,6 +15,7 @@ exports[`the PrayerSingle component renders a prayer card 1`] = `
   <View
     style={
       Object {
+        "marginVertical": 16,
         "paddingRight": 16,
       }
     }

--- a/src/prayer/PrayerSingle/index.js
+++ b/src/prayer/PrayerSingle/index.js
@@ -18,6 +18,7 @@ const GreyH5 = styled(({ theme }) => ({
 }))(H5);
 
 const PrayerView = styled(({ theme }) => ({
+  marginVertical: theme.sizing.baseUnit,
   paddingRight: theme.sizing.baseUnit,
 }))(View);
 


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the top and bottom margins of the prayer text to give it some more space. Honestly, I probably missed this when testing the scroll bar change ... so now I'm trying to fix it. 🤷‍♂️

Before:
![Screenshot 2020-03-12 10 11 58](https://user-images.githubusercontent.com/3229463/76531173-343d9f80-644b-11ea-982c-1d6e441e4e5f.png)

After:
![Screenshot 2020-03-12 10 12 23](https://user-images.githubusercontent.com/3229463/76531175-34d63600-644b-11ea-966b-47ff80c86004.png)

### How do I test this PR?
Open a prayer and make sure that it looks correctly. Long prayers should still respect the margin on the right for the scroll bar.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
