### PR TITLE
fix: Better Loading States

### DIFF
--- a/src/ui/HorizontalContentSeriesFeedConnected.js
+++ b/src/ui/HorizontalContentSeriesFeedConnected.js
@@ -20,6 +20,8 @@ const loadingStateObject = {
   node: {
     id: 'fakeId0',
     title: '',
+    hasAction: true,
+    actionIcon: 'play',
     coverImage: '',
     isLoading: true,
     parentChannel: {
@@ -49,6 +51,16 @@ class HorizontalContentSeriesFeedConnected extends Component {
     Component: HorizontalTileFeed,
   };
 
+  getCoverImage = (typename, videos) => {
+    let image;
+    if (typename === 'WeekendContentItem') {
+      image = videos.length ? videos[0].thumbnail.sources : '';
+    } else {
+      image = '';
+    }
+    return image;
+  };
+
   renderItem = ({ item }) => {
     const disabled = get(item, 'id', '') === this.props.contentId;
     const isLoading = get(item.node, 'isLoading');
@@ -58,34 +70,13 @@ class HorizontalContentSeriesFeedConnected extends Component {
         onPress={() => this.handleOnPressItem(item)}
         disabled={isLoading || disabled}
       >
-        <HorizontalContentCardConnected
-          Component={({ coverImage, ...props }) => {
-            switch (get(item, '__typename')) {
-              case 'WeekendContentItem':
-                return (
-                  <HorizontalContentCardConnected.defaultProps.Component
-                    coverImage={
-                      item.videos.length
-                        ? item.videos[0].thumbnail.sources
-                        : null
-                    }
-                    {...props}
-                  />
-                );
-              default:
-                return (
-                  <HorizontalContentCardConnected.defaultProps.Component
-                    coverImage={null}
-                    {...props}
-                  />
-                );
-            }
-          }}
+        <HorizontalContentCardConnected.defaultProps.Component
+          {...item}
           labelText={''}
           contentId={get(item, 'id', '')}
-          disabled={disabled}
+          hasAction={!!get(item, 'videos.[0].sources[0]', null)}
           isLoading={isLoading}
-          __typename={get(item, '__typename')}
+          coverImage={this.getCoverImage(get(item, '__typename'), item.videos)}
         />
       </TouchableScale>
     );

--- a/src/ui/HorizontalContentSeriesFeedConnected.js
+++ b/src/ui/HorizontalContentSeriesFeedConnected.js
@@ -130,6 +130,7 @@ class HorizontalContentSeriesFeedConnected extends Component {
             index,
           })}
           onEndReached={() =>
+            !loading &&
             fetchMore({
               query: GET_CONTENT_SERIES,
               variables: { cursor, itemId: this.props.contentId },
@@ -137,8 +138,8 @@ class HorizontalContentSeriesFeedConnected extends Component {
                 const connection = isParent
                   ? 'childContentItemsConnection'
                   : 'siblingContentItemsConnection';
-                const newEdges = get(fetchMoreResult.node, connection, [])
-                  .edges;
+                const newEdges =
+                  get(fetchMoreResult, `node.${connection}.edges`) || [];
 
                 return {
                   node: {

--- a/src/ui/HorizontalContentSeriesFeedConnected.js
+++ b/src/ui/HorizontalContentSeriesFeedConnected.js
@@ -52,8 +52,6 @@ class HorizontalContentSeriesFeedConnected extends Component {
   renderItem = ({ item }) => {
     const disabled = get(item, 'id', '') === this.props.contentId;
     const isLoading = get(item.node, 'isLoading');
-    console.log('isLoading = ', isLoading);
-    console.log('item = ', item);
 
     return (
       <TouchableScale
@@ -160,7 +158,6 @@ class HorizontalContentSeriesFeedConnected extends Component {
   };
 
   render() {
-    console.log('this.props.contentId = ', this.props.contentId);
     if (!this.props.contentId) return this.renderFeed({ loading: true });
 
     return (

--- a/src/ui/HorizontalContentSeriesFeedConnected.js
+++ b/src/ui/HorizontalContentSeriesFeedConnected.js
@@ -52,6 +52,8 @@ class HorizontalContentSeriesFeedConnected extends Component {
   renderItem = ({ item }) => {
     const disabled = get(item, 'id', '') === this.props.contentId;
     const isLoading = get(item.node, 'isLoading');
+    console.log('isLoading = ', isLoading);
+    console.log('item = ', item);
 
     return (
       <TouchableScale
@@ -99,7 +101,6 @@ class HorizontalContentSeriesFeedConnected extends Component {
 
   renderFeed = ({ data, loading, error, fetchMore }) => {
     if (error) return null;
-    if (loading) return null;
 
     const children = get(data, 'node.childContentItemsConnection.edges', []);
     const siblings = get(data, 'node.siblingContentItemsConnection.edges', []);
@@ -113,7 +114,7 @@ class HorizontalContentSeriesFeedConnected extends Component {
     );
     const initialScrollIndex = currentIndex === -1 ? 0 : currentIndex;
 
-    return content && content.length ? (
+    return (
       <PaddedView horizontal={false}>
         <PaddedView vertical={false}>
           <H5>In this series</H5>
@@ -155,10 +156,11 @@ class HorizontalContentSeriesFeedConnected extends Component {
           }
         />
       </PaddedView>
-    ) : null;
+    );
   };
 
   render() {
+    console.log('this.props.contentId = ', this.props.contentId);
     if (!this.props.contentId) return this.renderFeed({ loading: true });
 
     return (


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR makes the loading states for horizontal content items show up from the very beginning and not just show up (SURPRISE!) once they've actually loaded. This should also avoid the scenario where the horizontal content items seems to blink in and out as they are loading.

![loading state](https://user-images.githubusercontent.com/3229463/77956182-71a18a00-729f-11ea-8e6e-bb2468ccf3e6.gif)

### How do I test this PR?
Pull up some content items and see the horizontal content items should show up from the get go.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
