### PR TITLE
fix: Discover feed works again on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@apollosproject/ui-connected": "^1.3.1",
     "@apollosproject/ui-fragments": "^1.3.1",
     "@apollosproject/ui-htmlview": "^1.3.1",
-    "@apollosproject/ui-kit": "^1.3.1",
+    "@apollosproject/ui-kit": "^1.3.2",
     "@apollosproject/ui-mapview": "^1.3.1",
     "@apollosproject/ui-media-player": "^1.3.1",
     "@apollosproject/ui-notifications": "^1.3.1",

--- a/schema.graphql
+++ b/schema.graphql
@@ -526,6 +526,7 @@ type ScriptureFeature implements Feature & Node {
 type ScriptureNote implements SermonNote {
   id: ID!
   allowsCustomNote: Boolean
+  simpleText: String
   scripture: Scripture
 }
 
@@ -551,6 +552,7 @@ type SeriesConnection {
 interface SermonNote {
   id: ID!
   allowsCustomNote: Boolean
+  simpleText: String
 }
 
 interface Sharable {
@@ -586,8 +588,10 @@ type TextFeature implements Feature & Node {
 type TextNote implements SermonNote {
   id: ID!
   allowsCustomNote: Boolean
-  text: String
+  simpleText: String
   isHeader: Boolean
+  hasBlanks: Boolean
+  hiddenText: String
 }
 
 type Theme {

--- a/src/tabs/discover/__snapshots__/discover.tests.js.snap
+++ b/src/tabs/discover/__snapshots__/discover.tests.js.snap
@@ -261,7 +261,6 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                       <TextInput
                         allowFontScaling={true}
                         cancelButtonOffset={1000}
-                        color="#303030"
                         editable={true}
                         isFocused={false}
                         onChangeText={[Function]}
@@ -273,6 +272,7 @@ exports[`The Discover tab component Should retrieve the Content Channel Feeds 1`
                         selectionColor="#6bac43"
                         style={
                           Object {
+                            "color": "#303030",
                             "flexGrow": 1,
                             "fontFamily": "Colfax-Medium",
                             "fontSize": 14,

--- a/src/ui/SearchInputHeader/__snapshots__/SearchInputHeader.tests.js.snap
+++ b/src/ui/SearchInputHeader/__snapshots__/SearchInputHeader.tests.js.snap
@@ -170,7 +170,6 @@ exports[`The Onboarding LandingScreen component should be stylable 1`] = `
         <TextInput
           allowFontScaling={true}
           cancelButtonOffset={1000}
-          color="#303030"
           editable={true}
           isFocused={false}
           onChangeText={[Function]}
@@ -182,6 +181,7 @@ exports[`The Onboarding LandingScreen component should be stylable 1`] = `
           selectionColor="#6bac43"
           style={
             Object {
+              "color": "#303030",
               "flexGrow": 1,
               "fontFamily": "Colfax-Medium",
               "fontSize": 14,
@@ -569,7 +569,6 @@ exports[`The Onboarding LandingScreen component should render 1`] = `
         <TextInput
           allowFontScaling={true}
           cancelButtonOffset={1000}
-          color="#303030"
           editable={true}
           isFocused={false}
           onChangeText={[Function]}
@@ -581,6 +580,7 @@ exports[`The Onboarding LandingScreen component should render 1`] = `
           selectionColor="#6bac43"
           style={
             Object {
+              "color": "#303030",
               "flexGrow": 1,
               "fontFamily": "Colfax-Medium",
               "fontSize": 14,
@@ -968,7 +968,6 @@ exports[`The Onboarding LandingScreen component should render pass props to Sear
         <TextInput
           allowFontScaling={true}
           cancelButtonOffset={1000}
-          color="#303030"
           editable={true}
           isFocused={false}
           onChangeText={[Function]}
@@ -980,6 +979,7 @@ exports[`The Onboarding LandingScreen component should render pass props to Sear
           selectionColor="#6bac43"
           style={
             Object {
+              "color": "#303030",
               "flexGrow": 1,
               "fontFamily": "Colfax-Medium",
               "fontSize": 14,

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,6 +112,21 @@
     recompose "^0.30.0"
     rn-placeholder "1.2.0"
 
+"@apollosproject/ui-kit@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-1.3.2.tgz#87371ddd3052b881174a806e3b345f594d568566"
+  integrity sha512-E4ycvJ6eM7/NUegSu0Mhg3AyOd0wzx2ylsRH8JuGLPj0NLtnSglcJFiY+M6Ac3L3Sr+732L7fVy9iJFjhIbFoQ==
+  dependencies:
+    color "^3.1.0"
+    lodash "^4.17.11"
+    moment "^2.24.0"
+    numeral "^2.0.6"
+    react-native-modal-datetime-picker "7.6.0"
+    react-native-safe-area-context "^0.3.6"
+    react-native-tab-view "1.0.2"
+    recompose "^0.30.0"
+    rn-placeholder "1.2.0"
+
 "@apollosproject/ui-mapview@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@apollosproject/ui-mapview/-/ui-mapview-1.3.1.tgz#156245656b751a7079c44a882152665a289634c7"


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the search header so that it no longer crashes the app when you go to the Discover tab on Android.

### How do I test this PR?
Test the Discover feed on both iOS and Android and make sure that it loads correctly.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
