### PR TITLE
chore: Adds code freeze PR label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,6 +4,7 @@ pull_request_rules:
       - base=master
       - label=merge
       - label!=blocked
+      - label!=freeze
       - title~=^[fix|feat|chore|perf].*
     actions:
       merge:


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?

Let's us put a label on PRs so they won't be merged during a code freeze.

### How do I test this PR?

add the label, with approved and merge and make sure it doesn't go through.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [ ] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._