### PR TITLE
fix: Fixed Double Android Icons

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,16 +19,6 @@
             android:name="com.google.android.geo.API_KEY"
             android:value="@string/GOOGLE_MAPS_API_KEY" />
 
-        <activity	
-            android:name=".LaunchActivity"	
-            android:label="@string/app_name">	
-            <intent-filter>	
-                <action android:name="android.intent.action.MAIN" />	
-                <category android:name="android.intent.category.LAUNCHER" />	
-                <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />	
-            </intent-filter>	
-        </activity>
-
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
@@ -112,7 +102,7 @@
                     android:pathPrefix="/staff/news" />
             </intent-filter>
         </activity>
-        
+
         <activity
             android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"
             android:theme="@style/BootTheme"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "src"
   ],
   "scripts": {
-    "android": "SIM=\"$($HOME/Library/Android/sdk/emulator/emulator -list-avds | sed -n 1p)\" && $HOME/Library/Android/sdk/emulator/emulator -avd \"${SIM}\" & react-native run-android --appId cc.newspring.newspringapp --main-activity LaunchActivity",
+    "android": "SIM=\"$($HOME/Library/Android/sdk/emulator/emulator -list-avds | sed -n 1p)\" && $HOME/Library/Android/sdk/emulator/emulator -avd \"${SIM}\" & react-native run-android --appId cc.newspring.newspringapp",
     "codecov": "cat ./coverage/lcov.info | codecov",
     "ios": "react-native run-ios --simulator=\"iPhone 11\"",
     "lint": "eslint ./src --ext .js",


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2020-06-02 at 9 13 04 AM](https://user-images.githubusercontent.com/2659478/83524304-70fcbe00-a4b1-11ea-8886-58bb77ac752c.png)


### What does this PR do, or why is it needed?

Removes unnecessary launch activity

### How do I test this PR?

Boot the Android app

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._