### PR TITLE
fix: Fix Campaign Item Loading Incorrect Content

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@apollosproject/ui-connected": "1.4.1",
     "@apollosproject/ui-fragments": "1.4.1",
     "@apollosproject/ui-htmlview": "1.4.1",
-    "@apollosproject/ui-kit": "1.4.1",
+    "@apollosproject/ui-kit": "1.4.4-alpha.3+bded69a",
     "@apollosproject/ui-mapview": "1.4.1",
     "@apollosproject/ui-media-player": "1.4.1",
     "@apollosproject/ui-notifications": "1.4.1",

--- a/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerForm.tests.js.snap
+++ b/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerForm.tests.js.snap
@@ -77,7 +77,7 @@ exports[`The AddPrayerForm component should render 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -85,10 +85,10 @@ exports[`The AddPrayerForm component should render 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -104,14 +104,15 @@ exports[`The AddPrayerForm component should render 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={
@@ -770,7 +771,7 @@ exports[`The AddPrayerForm component should render a custom avatar 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -1392,7 +1393,7 @@ exports[`The AddPrayerForm component should render a custom title 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -1400,10 +1401,10 @@ exports[`The AddPrayerForm component should render a custom title 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -1419,14 +1420,15 @@ exports[`The AddPrayerForm component should render a custom title 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={

--- a/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerFormConnected.tests.js.snap
+++ b/src/prayer/AddPrayer/AddPrayerForm/__snapshots__/AddPrayerFormConnected.tests.js.snap
@@ -77,7 +77,7 @@ exports[`renders AddPrayerFormConnected 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -85,10 +85,10 @@ exports[`renders AddPrayerFormConnected 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -104,14 +104,15 @@ exports[`renders AddPrayerFormConnected 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={

--- a/src/prayer/AnswerPrayerForm/__snapshots__/AnswerPrayerForm.tests.js.snap
+++ b/src/prayer/AnswerPrayerForm/__snapshots__/AnswerPrayerForm.tests.js.snap
@@ -77,7 +77,7 @@ exports[`The AnswerPrayerForm component should render 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -85,10 +85,10 @@ exports[`The AnswerPrayerForm component should render 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -104,14 +104,15 @@ exports[`The AnswerPrayerForm component should render 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={
@@ -677,7 +678,7 @@ exports[`The AnswerPrayerForm component should render a custom avatar 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -1206,7 +1207,7 @@ exports[`The AnswerPrayerForm component should render a custom title 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -1214,10 +1215,10 @@ exports[`The AnswerPrayerForm component should render a custom title 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -1233,14 +1234,15 @@ exports[`The AnswerPrayerForm component should render a custom title 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={
@@ -1806,7 +1808,7 @@ exports[`The AnswerPrayerForm component should render something passed in the ac
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -1814,10 +1816,10 @@ exports[`The AnswerPrayerForm component should render something passed in the ac
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -1833,14 +1835,15 @@ exports[`The AnswerPrayerForm component should render something passed in the ac
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={
@@ -2412,7 +2415,7 @@ exports[`The AnswerPrayerForm component should render the prayer answer 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -2420,10 +2423,10 @@ exports[`The AnswerPrayerForm component should render the prayer answer 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -2439,14 +2442,15 @@ exports[`The AnswerPrayerForm component should render the prayer answer 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={
@@ -3014,7 +3018,7 @@ exports[`The AnswerPrayerForm component should render the prayer text 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -3022,10 +3026,10 @@ exports[`The AnswerPrayerForm component should render the prayer text 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -3041,14 +3045,15 @@ exports[`The AnswerPrayerForm component should render the prayer text 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={

--- a/src/prayer/AnswerPrayerForm/__snapshots__/AnswerPrayerFormConnected.tests.js.snap
+++ b/src/prayer/AnswerPrayerForm/__snapshots__/AnswerPrayerFormConnected.tests.js.snap
@@ -77,7 +77,7 @@ exports[`renders AnswerPrayerFormConnected 1`] = `
                 Object {
                   "alignItems": "center",
                   "height": 80,
-                  "justifyContent": "flex-end",
+                  "justifyContent": "center",
                   "width": 80,
                 }
               }
@@ -85,10 +85,10 @@ exports[`renders AnswerPrayerFormConnected 1`] = `
             >
               <RNSVGSvgView
                 align="xMidYMid"
-                bbHeight={80}
-                bbWidth={80}
+                bbHeight={87.5}
+                bbWidth={87.5}
                 focusable={false}
-                height={80}
+                height={87.5}
                 meetOrSlice={0}
                 minX={0}
                 minY={0}
@@ -104,14 +104,15 @@ exports[`renders AnswerPrayerFormConnected 1`] = `
                     },
                     Object {
                       "flex": 0,
-                      "height": 80,
-                      "width": 80,
+                      "height": 87,
+                      "width": 87,
                     },
                   ]
                 }
+                themeSize={80}
                 vbHeight={24}
                 vbWidth={24}
-                width={80}
+                width={87.5}
               >
                 <RNSVGGroup
                   fill={

--- a/src/prayer/PrayerHeader/__snapshots__/PrayerHeader.tests.js.snap
+++ b/src/prayer/PrayerHeader/__snapshots__/PrayerHeader.tests.js.snap
@@ -14,7 +14,7 @@ exports[`the PrayerHeader component renders an anonymous prayer header 1`] = `
         Object {
           "alignItems": "center",
           "height": 80,
-          "justifyContent": "flex-end",
+          "justifyContent": "center",
           "width": 80,
         }
       }
@@ -111,7 +111,7 @@ exports[`the PrayerHeader component renders the prayer header 1`] = `
         Object {
           "alignItems": "center",
           "height": 80,
-          "justifyContent": "flex-end",
+          "justifyContent": "center",
           "width": 80,
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,7 +97,23 @@
     entities "^1.1.2"
     htmlparser2 "3.9.2"
 
-"@apollosproject/ui-kit@1.4.1", "@apollosproject/ui-kit@^1.4.1":
+"@apollosproject/ui-kit@1.4.4-alpha.3+bded69a":
+  version "1.4.4-alpha.3"
+  resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-1.4.4-alpha.3.tgz#28859273999d4ba8fba63c3246d235ea9ead5802"
+  integrity sha512-6cj0p7U5EPr164x7y5lA23Kqxr78rbqhaIuZ+lpTfXefEx7JAZL43kZQcRfFQk+Iuw0cnfskPCCcoMjmtDQtoA==
+  dependencies:
+    "@react-native-community/blur" "^3.6.0"
+    color "^3.1.0"
+    lodash "^4.17.11"
+    moment "^2.24.0"
+    numeral "^2.0.6"
+    react-native-modal-datetime-picker "8.7.1"
+    react-native-safe-area-context "^0.3.6"
+    react-native-tab-view "1.0.2"
+    recompose "^0.30.0"
+    rn-placeholder "1.2.0"
+
+"@apollosproject/ui-kit@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@apollosproject/ui-kit/-/ui-kit-1.4.1.tgz#a4445ee89e30cc2c95d19ea293091e86ad36ad83"
   integrity sha512-sVAGWTEbAfkBuC5lTZULpH5GRU7MD4LBxYPWyPNwg0FN9Hn1MUt/RtyOdiVRI7wgDYAmFO6wC3Msa24DWps6mA==
@@ -2327,6 +2343,13 @@
   integrity sha512-TlGMr02JcmY4huH1P7Mt7p6wJecosPpW+09+CwCFLn875IhpRqU2XiVA+BQppZOYfQdHUfUzIKyCBeXOlCEbEg==
   dependencies:
     deep-assign "^3.0.0"
+
+"@react-native-community/blur@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/blur/-/blur-3.6.0.tgz#31c9e0f2770519c9b5c4f99418f192246f0d4db8"
+  integrity sha512-GtDBhpX2pQcjl4VopOC8FktrVufrEfYRwVeMQ2WWckqKIv2BdwvlvWvj88L1WmEdBr9UNcm3rtgz+d+YXkmirA==
+  dependencies:
+    prop-types "^15.5.10"
 
 "@react-native-community/cli-platform-android@^2.6.0", "@react-native-community/cli-platform-android@^2.9.0":
   version "2.9.0"


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
If you changed the campaign item in Rock and went to the app, the home feed would display the correct campaign item but if you tapped on that item it would sometimes show the prior campaign item. This PR includes an update to the `ui-kit` package that has a fix for that in it.

### How do I test this PR?
**Before using this branch:**
Point your API to `alpha-rock`
Start up the app and note the campaign item.
Go to `alpha-rock` and change the campaign item to something else.
Refresh the app. The home feed should reflect the new campaign item.
Tap on that campaign item. It should show the old campaign item.

Now pull this branch.
Do the same steps as before. 
When you tap on the campaign item it should correctly show you the content for the new campaign item.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
