### PR TITLE
fix: Fix Manage Group Link Caching

### DIFF
--- a/src/tabs/connect/Connect.js
+++ b/src/tabs/connect/Connect.js
@@ -51,7 +51,7 @@ class Connect extends PureComponent {
                 />
               )}
             />
-            <Query query={GET_USER_PROFILE}>
+            <Query query={GET_USER_PROFILE} fetchPolicy="cache-and-network">
               {({
                 data: {
                   currentUser: { profile: { isGroupLeader } = {} } = {},


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR fixes the "Manage your group" link on the Connect screen so that if you are added as a group leader the link will show up without you having to delete and reinstall the app.

### How do I test this PR?
Make sure you're not a group leader.
Go to the Connect screen and see that you don't have a "Manage your group" link.
Add yourself as a group leader to a group.
Refresh the app.
The "Manage your group" link should now appear.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
