### PR TITLE
chore: Turns off server-side analytics

### DIFF
--- a/src/Providers.js
+++ b/src/Providers.js
@@ -31,7 +31,10 @@ const AppProviders = (props) => (
       >
         <ExternalLinkProvider navigate={NavigationService.navigate}>
           <MediaPlayerProvider>
-            <AnalyticsProvider trackFunctions={[track]}>
+            <AnalyticsProvider
+              trackFunctions={[track]}
+              useServerAnalytics={false}
+            >
               <LiveProvider>
                 <Providers
                   themeInput={customTheme}


### PR DESCRIPTION
## DESCRIPTION

![Screen Shot 2020-07-16 at 8 45 04 AM](https://user-images.githubusercontent.com/2659478/87672575-312c2600-c741-11ea-81c0-622a61873856.png)


### What does this PR do, or why is it needed?

We were sending `track` mutations to the server that weren't doing anything at all. This turns that off.

### How do I test this PR?

Point the app to the server and verify when clicking items, you don't see any `track` mutations in the logs.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._