### PR TITLE
fix: Make the linking provider correctly handle deep links

### DIFF
--- a/src/linking/Provider.js
+++ b/src/linking/Provider.js
@@ -51,21 +51,25 @@ class ExternalLinkProvider extends Component {
   };
 
   _handleOpenURL = async (rawUrl) => {
-    const urlArray = rawUrl.url.split(/[\s/]+/);
-    const path = urlArray[urlArray.length - 1];
-    const slug = path.split('?')[0];
+    if (rawUrl.url.indexOf('newspringchurchapp') >= 0) {
+      this.navigate(rawUrl.url);
+    } else {
+      const urlArray = rawUrl.url.split(/[\s/]+/);
+      const path = urlArray[urlArray.length - 1];
+      const slug = path.split('?')[0];
 
-    const {
-      data: { contentItemFromSlug } = {},
-    } = await this.props.client.query({
-      query: GET_CONTENT_ITEM_BY_SLUG,
-      variables: { slug },
-    });
-    if (contentItemFromSlug) {
-      const newUrl = `newspringchurchapp://AppStackNavigator/ContentSingle?itemId=${
-        contentItemFromSlug.id
-      }`;
-      this.navigate(newUrl);
+      const {
+        data: { contentItemFromSlug } = {},
+      } = await this.props.client.query({
+        query: GET_CONTENT_ITEM_BY_SLUG,
+        variables: { slug },
+      });
+      if (contentItemFromSlug) {
+        const newUrl = `newspringchurchapp://AppStackNavigator/ContentSingle?itemId=${
+          contentItemFromSlug.id
+        }`;
+        this.navigate(newUrl);
+      }
     }
   };
 

--- a/src/linking/Provider.js
+++ b/src/linking/Provider.js
@@ -52,8 +52,13 @@ class ExternalLinkProvider extends Component {
 
   _handleOpenURL = async (rawUrl) => {
     if (rawUrl.url.indexOf('newspringchurchapp') >= 0) {
+      // if the URL starts with 'newspringchurchapp' then this is
+      // a deep link in the format it already needs to be in.
+      // So just navigate to it.
       this.navigate(rawUrl.url);
     } else {
+      // The link coming in is more like `https://newspring.cc/<something>
+      // We need to convert this to a deep link first, and then navigate.
       const urlArray = rawUrl.url.split(/[\s/]+/);
       const path = urlArray[urlArray.length - 1];
       const slug = path.split('?')[0];


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR updates the linking provider to correctly handle deep links (links with the format `newspringchurchapp://AppStackNavigator/<some location in the app>`). Before this change links like this would open the app, but they wouldn't correctly navigate to where they needed to go. It would only correctly open links using the `https://newspring.cc/<some location in the app>` format.

### How do I test this PR?
* Use the following command to make sure that a normal link works correctly. `xcrun simctl openurl booted https://newspring.cc/devotionals/40-days-of-prayer-and-fasting-guide/first-we-grieve`.
* Use the following command to make sure that a deep link works correctly. `xcrun simctl openurl booted "newspringchurchapp://AppStackNavigator/ContentSingle?itemId=DevotionalContentItem:4fda470e55c3f46d16c1b060ad525bd4"`
* These should both take you to the same place in the app. 

## TODO

- [ ] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] No new warnings
- [ ] Upload GIF(s) of iOS and Android if applicable
- [ ] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
