### PR TITLE
feat: Add Devo Ad Unit

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -494,6 +494,7 @@ type Person implements Node {
   groups(type: GROUP_TYPE, asLeader: Boolean): [Group]
   testGroups: [Group]
   isGroupLeader: Boolean
+  adUnit: Boolean
   impersonationParameter: String! @deprecated(reason: "No longer used.")
   isStaff: Boolean
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -494,7 +494,7 @@ type Person implements Node {
   groups(type: GROUP_TYPE, asLeader: Boolean): [Group]
   testGroups: [Group]
   isGroupLeader: Boolean
-  adUnit: Boolean
+  isInReadMyBible: Boolean
   impersonationParameter: String! @deprecated(reason: "No longer used.")
   isStaff: Boolean
 }

--- a/src/content-single/DevotionalContentItem/ContentTab.js
+++ b/src/content-single/DevotionalContentItem/ContentTab.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ScrollView, View } from 'react-native';
 import PropTypes from 'prop-types';
+import { Query } from 'react-apollo';
 import { RockAuthedWebBrowser } from '@apollosproject/ui-connected';
 import {
   BodyText,
@@ -15,6 +16,7 @@ import { ScriptureList } from '@apollosproject/ui-scripture';
 import HorizontalContentSeriesFeedConnected from '../../ui/HorizontalContentSeriesFeedConnected';
 import ContentHTMLViewConnected from '../../ui/ContentHTMLViewConnected';
 import MediaControls from '../../ui/MediaControls';
+import { GET_USER_PROFILE } from '../../tabs/connect/UserAvatarHeader';
 
 const MediaView = styled(({ theme }) => ({
   paddingTop: theme.sizing.baseUnit * 2,
@@ -52,47 +54,58 @@ const ContentTab = ({
   navigationState,
   navigation,
 }) => (
-  <ScrollView>
-    <ContentContainer isLoading={isLoading}>
-      <H2 padded>{title}</H2>
-      <MediaView>
-        <MediaControls contentId={id} />
-      </MediaView>
-      {references && references.length ? (
-        <ScriptureList
-          references={references}
-          onPress={navigationState.route.jumpTo} // eslint-disable-line react/jsx-handler-names
-          tabDestination={'scripture'}
-        />
-      ) : null}
-      <ContentHTMLViewConnected contentId={id} />
-      <RockAuthedWebBrowser>
-        {(openUrl) => (
-          <AdUnit>
-            <AdUnitH3>Daily Devotionals, Delivered Every Morning</AdUnitH3>
-            <BodyText>
-              Sign up to receive daily devotionals via text message every
-              morning.
-            </BodyText>
-            <AdUnitButton
-              title={'Subscribe Now'}
-              onPress={() =>
-                openUrl(
-                  'https://newspring.cc/workflows/510?CommunicationList=5e888a13-b0b5-411f-87bd-fd3352deca31&hidenav=true',
-                  {},
-                  { useRockToken: true }
-                )
-              }
-            />
-          </AdUnit>
-        )}
-      </RockAuthedWebBrowser>
-    </ContentContainer>
-    <HorizontalContentSeriesFeedConnected
-      contentId={id}
-      navigation={navigation}
-    />
-  </ScrollView>
+  <Query query={GET_USER_PROFILE} fetchPolicy="cache-and-network">
+    {({ data: { currentUser = { profile: {} } } = {} }) => {
+      const { isInReadMyBible } = currentUser.profile;
+      return (
+        <ScrollView>
+          <ContentContainer isLoading={isLoading}>
+            <H2 padded>{title}</H2>
+            <MediaView>
+              <MediaControls contentId={id} />
+            </MediaView>
+            {references && references.length ? (
+              <ScriptureList
+                references={references}
+                onPress={navigationState.route.jumpTo} // eslint-disable-line react/jsx-handler-names
+                tabDestination={'scripture'}
+              />
+            ) : null}
+            <ContentHTMLViewConnected contentId={id} />
+            {!isInReadMyBible ? (
+              <RockAuthedWebBrowser>
+                {(openUrl) => (
+                  <AdUnit>
+                    <AdUnitH3>
+                      Daily Devotionals, Delivered Every Morning
+                    </AdUnitH3>
+                    <BodyText>
+                      Sign up to receive daily devotionals via text message
+                      every morning.
+                    </BodyText>
+                    <AdUnitButton
+                      title={'Subscribe Now'}
+                      onPress={() =>
+                        openUrl(
+                          'https://newspring.cc/workflows/510?CommunicationList=5e888a13-b0b5-411f-87bd-fd3352deca31&hidenav=true',
+                          {},
+                          { useRockToken: true }
+                        )
+                      }
+                    />
+                  </AdUnit>
+                )}
+              </RockAuthedWebBrowser>
+            ) : null}
+          </ContentContainer>
+          <HorizontalContentSeriesFeedConnected
+            contentId={id}
+            navigation={navigation}
+          />
+        </ScrollView>
+      );
+    }}
+  </Query>
 );
 
 ContentTab.propTypes = {

--- a/src/content-single/DevotionalContentItem/ContentTab.js
+++ b/src/content-single/DevotionalContentItem/ContentTab.js
@@ -1,7 +1,16 @@
 import React from 'react';
-import { ScrollView } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import PropTypes from 'prop-types';
-import { PaddedView, H2, styled, withIsLoading } from '@apollosproject/ui-kit';
+import { RockAuthedWebBrowser } from '@apollosproject/ui-connected';
+import {
+  BodyText,
+  Button,
+  PaddedView,
+  H2,
+  H3,
+  styled,
+  withIsLoading,
+} from '@apollosproject/ui-kit';
 import { ScriptureList } from '@apollosproject/ui-scripture';
 import HorizontalContentSeriesFeedConnected from '../../ui/HorizontalContentSeriesFeedConnected';
 import ContentHTMLViewConnected from '../../ui/ContentHTMLViewConnected';
@@ -15,6 +24,20 @@ const MediaView = styled(({ theme }) => ({
 const ContentContainer = withIsLoading(
   styled({ paddingVertical: 0 })(PaddedView)
 );
+
+const AdUnit = styled(({ theme }) => ({
+  padding: theme.sizing.baseUnit * 2,
+  backgroundColor: theme.colors.lightTertiary,
+  borderRadius: 10,
+}))(View);
+
+const AdUnitH3 = styled(({ theme }) => ({
+  paddingBottom: theme.sizing.baseUnit,
+}))(H3);
+
+const AdUnitButton = styled(({ theme }) => ({
+  marginTop: theme.sizing.baseUnit,
+}))(Button);
 
 /**
  * This is the Content side of the Devotional tabbed component.
@@ -43,6 +66,27 @@ const ContentTab = ({
         />
       ) : null}
       <ContentHTMLViewConnected contentId={id} />
+      <RockAuthedWebBrowser>
+        {(openUrl) => (
+          <AdUnit>
+            <AdUnitH3>Daily Devotionals, Delivered Every Morning</AdUnitH3>
+            <BodyText>
+              Sign up to receive daily devotionals via text message every
+              morning.
+            </BodyText>
+            <AdUnitButton
+              title={'Subscribe Now'}
+              onPress={() =>
+                openUrl(
+                  'https://newspring.cc/workflows/510?CommunicationList=5e888a13-b0b5-411f-87bd-fd3352deca31&hidenav=true',
+                  {},
+                  { useRockToken: true }
+                )
+              }
+            />
+          </AdUnit>
+        )}
+      </RockAuthedWebBrowser>
     </ContentContainer>
     <HorizontalContentSeriesFeedConnected
       contentId={id}

--- a/src/content-single/DevotionalContentItem/ContentTab.js
+++ b/src/content-single/DevotionalContentItem/ContentTab.js
@@ -39,6 +39,8 @@ const AdUnitH3 = styled(({ theme }) => ({
 
 const AdUnitButton = styled(({ theme }) => ({
   marginTop: theme.sizing.baseUnit,
+  backgroundColor: theme.colors.secondary,
+  borderColor: theme.colors.secondary,
 }))(Button);
 
 /**

--- a/src/content-single/DevotionalContentItem/__snapshots__/Devotional.tests.js.snap
+++ b/src/content-single/DevotionalContentItem/__snapshots__/Devotional.tests.js.snap
@@ -522,6 +522,96 @@ exports[`the Devotional component renders a devotional 1`] = `
                                     }
                                   />
                                 </View>
+                                <View
+                                  style={
+                                    Object {
+                                      "backgroundColor": "#dddddd",
+                                      "borderRadius": 10,
+                                      "padding": 32,
+                                    }
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      Object {
+                                        "color": "#303030",
+                                        "fontFamily": "Colfax-Black",
+                                        "fontSize": 24,
+                                        "lineHeight": 27.6,
+                                        "paddingBottom": 16,
+                                      }
+                                    }
+                                  >
+                                    Daily Devotionals, Delivered Every Morning
+                                  </Text>
+                                  <Text
+                                    bold={false}
+                                    italic={false}
+                                    style={
+                                      Object {
+                                        "color": "#303030",
+                                        "fontFamily": "Colfax-Regular",
+                                        "fontSize": 16,
+                                        "lineHeight": 26,
+                                      }
+                                    }
+                                  >
+                                    Sign up to receive daily devotionals via text message every morning.
+                                  </Text>
+                                  <View
+                                    accessible={true}
+                                    clickable={true}
+                                    isTVSelectable={true}
+                                    onClick={[Function]}
+                                    onResponderGrant={[Function]}
+                                    onResponderMove={[Function]}
+                                    onResponderRelease={[Function]}
+                                    onResponderTerminate={[Function]}
+                                    onResponderTerminationRequest={[Function]}
+                                    onStartShouldSetResponder={[Function]}
+                                    style={
+                                      Object {
+                                        "opacity": 1,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      bordered={false}
+                                      disabled={false}
+                                      pill={true}
+                                      style={
+                                        Object {
+                                          "alignItems": "center",
+                                          "backgroundColor": "#6bac43",
+                                          "borderColor": "#6bac43",
+                                          "borderRadius": 48,
+                                          "borderWidth": 2,
+                                          "elevation": 2,
+                                          "flexDirection": "row",
+                                          "height": 48,
+                                          "justifyContent": "center",
+                                          "marginTop": 16,
+                                          "opacity": 1,
+                                          "overflow": "hidden",
+                                          "paddingHorizontal": 16,
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        style={
+                                          Object {
+                                            "color": "#ffffff",
+                                            "fontFamily": "Colfax-Bold",
+                                            "fontSize": 16,
+                                            "lineHeight": 23.04,
+                                          }
+                                        }
+                                      >
+                                        Subscribe Now
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
                               </View>
                             </View>
                           </RCTScrollView>

--- a/src/tabs/connect/UserAvatarHeader/getUserProfile.js
+++ b/src/tabs/connect/UserAvatarHeader/getUserProfile.js
@@ -6,6 +6,7 @@ export default gql`
     currentUser {
       id
       profile {
+        isInReadMyBible
         isGroupLeader
         ...UserProfileParts
         campus {


### PR DESCRIPTION
## DESCRIPTION

### What does this PR do, or why is it needed?
This PR adds an add unit to the bottom of the devotional content tab encouraging people to sign up to get their daily devo texted to them every morning. This only shows for people that do not currently get the Read My Bible texts.

### How do I test this PR?
Go and look at a devotional. If you are a part of the Read My Bible group you should see no change. If you are not a part of the Read My Bible group you should see the following ad unit:

![Screen Shot 2020-10-07 at 10 48 24 AM](https://user-images.githubusercontent.com/3229463/95347197-a1eb6600-088a-11eb-92ef-b48e5e5dc6f6.png)

The button should take you to the workflow to sign up.

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [x] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
