### PR TITLE
Fix issue where sermon notes are only populated as you enter text

### DIFF
--- a/src/content-single/SermonNotes/NoteComment/index.js
+++ b/src/content-single/SermonNotes/NoteComment/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Mutation } from '@apollo/client/react/components';
 import GET_SERMON_NOTES from '../getSermonNotes';
@@ -18,6 +18,14 @@ const NoteCommentConnected = ({ contentID, noteID, onChange, initialText }) => {
     const newTimer = setTimeout(saveComment, 3000);
     setTimer(newTimer);
   };
+
+  // pre-fill sermon note exports
+  useEffect(
+    () => {
+      onChange(initialText);
+    },
+    [onChange, initialText]
+  );
   return (
     <Mutation
       mutation={SAVE_NOTES_COMMENT}


### PR DESCRIPTION
## DESCRIPTION

@redreceipt if you can do a code/sanity review on this - basically the issue with sermon notes I believe is if you try to export notes that you previously entered. Basically if you enter notes, close the content item, and open the content item back up and export your notes, the export won't contain anything that you previously typed - only the new things. This fixes that by using a `useEffect` to call the `onChange` function (that populates the export) when the `initialText` (text that's loaded from the server) changes.

### What does this PR do, or why is it needed?

### How do I test this PR?

## TODO

- [x] I am affirming this is my _best_ work ([Ecclesiastes 9:10](https://www.bible.com/bible/97/ECC.9.10.MSG))
- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings
- [ ] Upload GIF(s) of iOS and Android if applicable
- [x] Set a relevant reviewer

## REVIEW

- [ ] Review updates to test coverage and snapshots
- [ ] Review code through the lens of being concise, simple, and well-documented

**Manual QA**

- [ ] Manual QA on iOS and ensure it looks/behaves as expected
- [ ] Manual QA on Android and ensure it looks/behaves as expected

---

> The purpose of PR Review is to _improve the quality of the software._
